### PR TITLE
fix: the control parameter focus_auto is now focus_automatic_continuous

### DIFF
--- a/fix-Logitech-HD-Pro-Webcam-C920.sh
+++ b/fix-Logitech-HD-Pro-Webcam-C920.sh
@@ -45,6 +45,6 @@ fi
 webcam_name="$(v4l2-ctl --device "$video_device" --info | grep -E '^\s+Card type\s+:' | sed -E 's/^.*?:\s+//')"
 echo "Found video device: $video_device for $webcam_name"
 
-v4l2-ctl --device "$video_device" --set-ctrl=focus_auto=0
+v4l2-ctl --device "$video_device" --set-ctrl=focus_automatic_continuous=0
 
 exit 0


### PR DESCRIPTION
### fix: the control parameter focus_auto is now focus_automatic_continuous

The parameter `focus_auto` is no longer working. When we run:

```bash
v4l2-ctl --device /dev/web-c920 --set-ctrl=focus_auto=0
```

We get:

```
unknown control 'focus_auto'
```

It seems that the parameter is now named `focus_automatic_continuous`.

See https://github.com/mainsail-crew/crowsnest/issues/96